### PR TITLE
Fix JSON to object at POST.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -204,7 +204,7 @@ var findPath = function(req, res, router, cb) {
   },
   ReqToObject = function(req, res, route) {
     req.on('data', function(data) {
-      req.body = queryStringToJSON(data.toString());
+      req.body = JSON.parse(data.toString());
       route.callback(req, res);
     });
   };


### PR DESCRIPTION
Hi,

I fixed the JSON parse at POST method. I only test POST method to sending JSON string with Chrome Postman extension. The *queryStringToJSON()* function that you use for all methods except GET, expects *req.url*. But, the *data.toString()* is JSON string comes with POST body. You may consider other than POST method.