### PR TITLE
Add method render on res parameter

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -201,6 +201,23 @@ var findPath = function(req, res, router, cb) {
     res.sendImage = function() {
       router.sendImageFn.apply(res, arguments);
     };
+    res.render = function(file, context){
+      if (typeof router.engine === 'string') {
+        var engine = require(router.engine)
+
+        router.fs.readFile(router.view + '/' + file + '.' + router.engine, function (err, data) {
+          var _html = engine.render(data.toString(), context)
+          res.send(_html)
+        })
+      } else {
+        var engine = require(router.engine.eng)
+
+        router.fs.readFile(router.view + '/' + file + '.' + router.engine.ext, function (err, data) {
+          var _html = engine.render(data.toString(), context)
+          res.send(_html)
+        })
+      }
+    };
   },
   ReqToObject = function(req, res, route) {
     req.on('data', function(data) {


### PR DESCRIPTION
This change it's better for use that (send) method.

It's necessery use the method (use) for the render method work

route.use('engine', 'ejs') 
or
route.use('engine', {eng: 'Mustache', ext: 'msc' }) <-- will help if the engine have a name and extension have another name

route.use('view', __dirname + '/views') <-- pattern dir to help render method

Support engine: EJS, MUSTACHE, HALM AND PUG.